### PR TITLE
fix: added export and split css and js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.esm.js",
+      "require": "./index.js"
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,7 @@ const rollupConfig = [
         tsconfig: './tsconfig.json',
       }),
       postcss({
-        extract: false,
+        extract: true,
         modules: false,
         use: ['sass'],
       }),
@@ -74,7 +74,7 @@ const rollupConfig = [
         tsconfig: './tsconfig.json',
       }),
       postcss({
-        extract: false,
+        extract: true,
         modules: false,
         use: ['sass'],
       }),


### PR DESCRIPTION
## Ticket
[Replace use of Create React App with Vite](https://github.com/US-EPA-CAMD/easey-ui/issues/6545)

## Changes

- Added export in package.json file
- Splited `js` and `css` by using `postcss` `extract: true`,
