### PR TITLE
fix(deps): upgrade vite from v6 to v7 Updates vite to ^7.3.2 

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -158,7 +158,7 @@ export const Header = ({
     <div className="header-container">
       <GovBanner className="padding-y-2px bg-base-lighter width-full" />
       <div className={`usa-overlay ${menuExpanded ? 'is-visible' : ''}`} />
-      {environment && environment !== 'prod' ? <EnvBanner label={environment} /> : null}
+      {environment && !['prod', 'production'].includes(environment) ? <EnvBanner label={environment} /> : null}
       <USWDSHeader basic={true} className="margin-bottom-neg-1">
         <a href={logoUrl} target="_blank" rel="noopener noreferrer" title="EPA Home page">
           {_.isNil(logoSrc) || logoSrc === '' ? (


### PR DESCRIPTION
fix(deps): upgrade vite from v6 to v7 Updates vite to ^7.3.2 to align with easey-ecmps-ui and easey-campd-ui, resolving Dependabot alerts #193, #194, and #195. Header handles both 'prod' or 'production' values for *_ENV value.