### PR TITLE
fix(build): externalize react-uswds so Vite 8 bundle is browser-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.0.0",
-    "@trussworks/react-uswds": "^4.1.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.19.21",
     "@types/react": "^18.2.0",
@@ -205,6 +204,7 @@
     }
   },
   "dependencies": {
-    "@ramonak/react-progress-bar": "^5.0.0"
+    "@ramonak/react-progress-bar": "^5.0.0",
+    "@trussworks/react-uswds": "^4.1.1"
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -32,9 +32,19 @@ export default defineConfig({
       },
       formats: ['es', 'cjs'] // Specify the formats you want to generate
     },
-    rollupOptions: {
+    rolldownOptions: {
       input: resolve(__dirname, 'src/index.ts'),
-      external: ['react', 'react-dom'],
+      // Externalize React AND react-uswds. react-uswds is CJS-only and does `require("react")`;
+      // Rolldown intentionally keeps an external `require()` as-is, so bundling react-uswds here
+      // leaks that call into consumers' browser bundles (crash). Externalizing it means the
+      // consuming app bundles react-uswds itself (where React is in-graph, not external), which
+      // resolves the require cleanly. react-uswds must therefore be declared as a runtime
+      // dependency/peerDependency of this package (see package.json).
+      external: [
+        /^react(\/|$)/,
+        /^react-dom(\/|$)/,
+        /^@trussworks\/react-uswds(\/|$)/,
+      ],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
fix(build): externalize react-uswds so Vite 8 bundle is browser-safe